### PR TITLE
Disabling h-screen on main app element

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     
   </head>
   <body class="leading-normal tracking-normal text-white gradient">
-    <div id="app" class="flex flex-col h-screen min-h-screen"></div>
+    <div id="app" class="flex flex-col min-h-screen"></div>
     <script type="module" src="/src/main.js"></script>
     
   </body>


### PR DESCRIPTION
The `h-screen` class on the `app` div seems to be messing up with the height of some pages, resulting in a layout where the footer stays on top of the main content.

![Screenshot 2021-12-28 at 8 46 13 PM](https://user-images.githubusercontent.com/1638325/147601760-c79aef86-aaa1-4d79-b5d5-3124c2879b56.jpg)
