### PR TITLE
add `rel="noopener"` to links

### DIFF
--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -119,6 +119,7 @@
             <li v-if="regFormOpen" @click="isOpen = false">
               <a
                 target="_blank"
+                rel="noopener"
                 class="
                   flex
                   text-lg
@@ -234,6 +235,7 @@
             <a
               active-class="bg-blue-800"
               target="_blank"
+              rel="noopener"
               class="uppercase inline-block p-5 text-white no-underline"
               :href="formUrl"
               >Register</a

--- a/src/components/Register.vue
+++ b/src/components/Register.vue
@@ -6,6 +6,7 @@
             <a
               class="text-white"
               target="_blank"
+              rel="noopener"
               :href="formUrl"
             >
               <div

--- a/src/views/Curriculum.vue
+++ b/src/views/Curriculum.vue
@@ -37,6 +37,7 @@
                   class="underline"
                   href="https://aka.ms/webdev-beginners"
                   target="_blank"
+                  rel="noopener"
                   >"Web Dev for Beginners"</a
                 >
                 curriculum, developed by a team led by Jen. In addition, we

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -17,6 +17,7 @@
               class="cursor-pointer underline"
               href="https://forms.gle/GA9pUe8AFkcJJQvSA"
               target="_blank"
+              rel="noopener"
               >self-study class</a
             >
             any time!
@@ -49,6 +50,7 @@
                 hover:bg-secondary-400
               "
               target="_blank"
+              rel="noopener"
               :href="formUrl"
               ><div class="uppercase text-center text-lg">Register</div></a
             >

--- a/src/views/OurSchool.vue
+++ b/src/views/OurSchool.vue
@@ -63,6 +63,7 @@
               class="underline"
               href="https://aka.ms/webdev-beginners"
               target="_blank"
+              rel="noopener"
               >"Web Dev for Beginners"</a
             >
             curriculum, developed by a team led by Jen.

--- a/src/views/Reports.vue
+++ b/src/views/Reports.vue
@@ -20,6 +20,7 @@
               class="font-bold text-1xl text-gray-600 underline"
               href="/reports/annual-report-2018-min.pdf"
               target="_blank"
+              rel="noopener"
               >2018</a
             >
           </div>
@@ -34,6 +35,7 @@
               class="font-bold text-1xl text-gray-600 underline"
               href="/reports/annual-report-2019-min.pdf"
               target="_blank"
+              rel="noopener"
               >2019</a
             >
           </div>
@@ -48,6 +50,7 @@
               class="font-bold text-1xl text-gray-600 underline"
               href="/reports/annual-report-2020-min.pdf"
               target="_blank"
+              rel="noopener"
               >2020</a
             >
           </div>

--- a/src/views/Sponsors.vue
+++ b/src/views/Sponsors.vue
@@ -34,6 +34,7 @@
                       class="underline"
                       href="https://herodevs.com"
                       target="_blank"
+                      rel="noopener"
                       >https://www.herodevs.com</a
                     >.
                   </p>
@@ -62,6 +63,7 @@
                       class="underline"
                       href="https://passionatepeople.io"
                       target="_blank"
+                      rel="noopener"
                       >https://www.passionatepeople.io</a
                     >.
                   </p>
@@ -102,6 +104,7 @@
                       class="underline"
                       href="https://www.telerik.com/kendo-ui"
                       target="_blank"
+                      rel="noopener"
                       >https://www.telerik.com/kendo-ui</a
                     >.
                   </p>
@@ -140,6 +143,7 @@
                       class="underline"
                       href="https://pachicodes.com"
                       target="_blank"
+                      rel="noopener"
                       >PachiCodes.com</a
                     >.
                   </p>
@@ -168,6 +172,7 @@
                       class="underline"
                       href="https://github.com/sponsors/FrontEndFoxes"
                       target="_blank"
+                      rel="noopener"
                       >GitHub Sponsors</a
                     >.
                   </p>
@@ -195,6 +200,7 @@
                   <a
                     class="text-white mt-6 rounded-lg py-3 bg-blue-800 hover:bg-blue-500"
                     target="_blank"
+                    rel="noopener"
                     href="https://us7.list-manage.com/contact-form?u=bb4724549551e6cf7bb5e3165&form_id=b15c2877e7d0009daf90e6911111e5b4"
                     ><span class="p-5 uppercase text-center text-lg">
                       Contact us for a Prospectus


### PR DESCRIPTION
Task: add `rel="noopener"` to links using `target="_blank"` 

Result: 
- Increase security in legacy browsers including Edge Legacy and Internet Explorer 
- May increase performance
[Learn more](https://web.dev/external-anchors-use-rel-noopener/?utm_source=lighthouse&utm_medium=devtools)